### PR TITLE
Update build.sh to support new pandoc.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ for i in */ ; do
    done ;
 done | pandoc                           \
   --toc                                 \
-  --filter pandoc-citeproc              \
+  --citeproc                            \
   --bibliography=../_references.bibtex  \
   --number-sections                     \
   --top-level-division=part             \


### PR DESCRIPTION
pandoc >= 2.11 uses internal citeproc instead of filter pandoc-citeproc

Updated flag in script to reflect changes.

## Synopsis of Changes

pandoc >= 2.11 uses internal citeproc instead of filter pandoc-citeproc

## Proposed Changes

    --filter pandoc-citeproc.    \

to

    --citeproc                            \

This will skip the filter or external version and use the internal pandoc version
  
## Steps to Test
  
  - Pull this Branch
    - git pull
    - git checkout [This Branch]
    - sh build.sh
    - Validate Build Worked
